### PR TITLE
add optional gamepad support

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       window.requestAnimationFrame(listenToGamepad)
     })
     window.addEventListener('gamepaddisconnected', function(e) {
-      gamepad = false
+      gamepadConnected = false
     })
 
   </script>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,23 @@
         }
     }, false);
     window.focus();
+    // Controller support
+    function listenToGamepad () {
+      if (gamepadConnected && navigator.getGamepads) {
+        var gamepad = navigator.getGamepads()[0]
+        app.ports.gamepad.send(gamepad)
+        window.requestAnimationFrame(listenToGamepad)
+      }
+    }
+    var gamepadConnected = false
+    window.addEventListener('gamepadconnected', function(e) {  
+      gamepadConnected = true  
+      window.requestAnimationFrame(listenToGamepad)
+    })
+    window.addEventListener('gamepaddisconnected', function(e) {
+      gamepad = false
+    })
+
   </script>
 </body>
 </html>

--- a/src/Components/Gamepad.elm
+++ b/src/Components/Gamepad.elm
@@ -1,0 +1,64 @@
+module Components.Gamepad exposing
+    ( Gamepad
+    , fromJson
+    )
+
+import Array exposing (Array)
+import Json.Decode as D exposing (Decoder)
+
+
+type alias Gamepad =
+    { a : Bool
+    , left : Bool
+    , right : Bool
+    }
+
+
+type alias JsGamepad =
+    { buttons : Array Button
+    , axes : Array Float
+    }
+
+
+type alias Button =
+    { value : Float
+    , pressed : Bool
+    }
+
+
+fromJson : D.Value -> Gamepad
+fromJson json =
+    D.decodeValue decoder json
+        |> Result.withDefault (Gamepad False False False)
+
+
+decoder : Decoder Gamepad
+decoder =
+    D.map2 JsGamepad
+        (D.field "buttons" (D.array buttonDecoder))
+        (D.field "axes" (D.array D.float))
+        |> D.map toGamepad
+
+
+buttonDecoder : Decoder Button
+buttonDecoder =
+    D.map2 Button
+        (D.field "value" D.float)
+        (D.field "pressed" D.bool)
+
+
+toGamepad : JsGamepad -> Gamepad
+toGamepad { buttons, axes } =
+    Gamepad
+        (Array.get 0 buttons
+            |> Maybe.map .pressed
+            |> Maybe.withDefault False
+        )
+        (Array.get 0 axes
+            |> Maybe.map (\float -> float < -0.25)
+            |> Maybe.withDefault False
+        )
+        (Array.get 0 axes
+            |> Maybe.map (\float -> float > 0.25)
+            |> Maybe.withDefault False
+        )

--- a/src/Components/Keys.elm
+++ b/src/Components/Keys.elm
@@ -5,11 +5,13 @@ module Components.Keys exposing
     , codes
     , directions
     , down
+    , gamepadChange
     , initial
     , keyChange
     , pressed
     )
 
+import Components.Gamepad exposing (Gamepad)
 import Dict exposing (Dict)
 
 
@@ -55,6 +57,14 @@ keyChange on code keys =
 
     else
         Dict.remove code keys
+
+
+gamepadChange : Gamepad -> Keys -> Keys
+gamepadChange gamepad =
+    keyChange gamepad.a codes.enter
+        >> keyChange gamepad.a codes.up
+        >> keyChange gamepad.left codes.left
+        >> keyChange gamepad.right codes.right
 
 
 animate : Float -> Keys -> Keys

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -10,10 +10,12 @@ import Browser.Events
         , onResize
         , onVisibilityChange
         )
+import Components.Gamepad as Gamepad
 import Html.Events exposing (keyCode)
 import Json.Decode as Decode exposing (Value)
 import Messages exposing (Msg(..))
 import Model exposing (Model)
+import Ports exposing (gamepad)
 import Task exposing (Task)
 import View
 import View.Font as Font
@@ -28,6 +30,7 @@ subscriptions _ =
         , onKeyUp (Decode.map (KeyChange False) keyCode)
         , onResize Resize
         , onVisibilityChange VisibilityChange
+        , gamepad (Gamepad.fromJson >> GamepadChange)
         ]
 
 

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -1,6 +1,7 @@
 module Messages exposing (Msg(..))
 
 import Browser.Events exposing (Visibility(..))
+import Components.Gamepad exposing (Gamepad)
 import WebGL.Texture exposing (Error, Texture)
 
 
@@ -8,6 +9,7 @@ type Msg
     = Resize Int Int
     | Animate Float
     | KeyChange Bool Int
+    | GamepadChange Gamepad
     | VisibilityChange Visibility
     | TextureLoaded (Result Error Texture)
     | SpriteLoaded (Result Error Texture)

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,4 +1,4 @@
-port module Model exposing
+module Model exposing
     ( GameState(..)
     , Model
     , initial
@@ -7,9 +7,11 @@ port module Model exposing
 
 import Browser.Events exposing (Visibility(..))
 import Components.Components as Components exposing (Components)
+import Components.Gamepad as Gamepad
 import Components.Keys as Keys exposing (Keys, codes)
 import Components.Menu as Menu exposing (Menu)
 import Messages exposing (Msg(..))
+import Ports exposing (play, sound, stop)
 import Slides.Engine as Engine exposing (Engine)
 import Slides.Slides as Slides
 import Systems.Systems as Systems exposing (Systems)
@@ -58,21 +60,6 @@ initial =
     }
 
 
-{-| port for turning audio on/off
--}
-port sound : Bool -> Cmd msg
-
-
-{-| port for sending audio to play
--}
-port play : String -> Cmd msg
-
-
-{-| port for sending audio to stop
--}
-port stop : String -> Cmd msg
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update action model =
     case action of
@@ -101,6 +88,11 @@ update action model =
                         _ ->
                             model.padding
               }
+            , Cmd.none
+            )
+
+        GamepadChange gamepad_ ->
+            ( { model | keys = Keys.gamepadChange gamepad_ model.keys }
             , Cmd.none
             )
 

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,0 +1,28 @@
+port module Ports exposing
+    ( gamepad
+    , play
+    , sound
+    , stop
+    )
+
+import Json.Decode exposing (Value)
+
+
+{-| port for turning audio on/off
+-}
+port sound : Bool -> Cmd msg
+
+
+{-| port for sending audio to play
+-}
+port play : String -> Cmd msg
+
+
+{-| port for sending audio to stop
+-}
+port stop : String -> Cmd msg
+
+
+{-| port for handling gamepad
+-}
+port gamepad : (Value -> msg) -> Sub msg


### PR DESCRIPTION
Hey there @w0rm ,

I recently started playing around with the [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API) and Elm yesterday, and was able to add optional controller support to Mogee!

I've been playing Mogee on my couch with an Xbox 360 controller!

Thanks for the cool game- hope you have a controller to try it out with (`a` to jump, left joystick to move)

Thanks again! 😄 
Ryan